### PR TITLE
Update maven repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ configurations {
 repositories {
     jcenter()
     maven {
-        url "https://maven.alfresco.com/nexus/content/repositories/activiti/"
+        url "https://artefacts.alfresco.com/nexus/content/repositories/activiti-releases/"
     }
     maven { url 'https://jitpack.io' }
 }


### PR DESCRIPTION
Fix build failure:

```
* What went wrong:
Could not resolve all files for configuration ':compileClasspath'.
> Could not download org.activiti.designer.model.jar (org.activiti.designer:org.activiti.designer.model:5.10.0)
   > Could not get resource 'https://maven.alfresco.com/nexus/content/repositories/activiti/org/activiti/designer/org.activiti.designer.model/5.10.0/org.activiti.designer.model-5.10.0.jar'.
      > Could not GET 'https://maven.alfresco.com/nexus/content/repositories/activiti/org/activiti/designer/org.activiti.designer.model/5.10.0/org.activiti.designer.model-5.10.0.jar'. Received status code 503 from server: Service Unavailable
```