### PR TITLE
Improves itemSubjectRef

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -65,9 +65,9 @@ configurations {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
     maven {
-        url "https://maven.alfresco.com/nexus/content/repositories/activiti/"
+        url "https://artefacts.alfresco.com/nexus/content/repositories/activiti-releases/"
     }
     maven { url 'https://jitpack.io' }
 }
@@ -88,7 +88,7 @@ dependencies {
     compile 'com.github.matthiasgeiger:mojo.core:master-SNAPSHOT'
     compile 'com.github.guybrushPrince:mojo.reader.bpmn:master-SNAPSHOT'
 
-	external files(fileTree(dir: "lib", includes: ['*.jar']))
+    external files(fileTree(dir: "lib", includes: ['*.jar']))
 
 	testCompile 'junit:junit:4.+'
 

--- a/src/main/resources/EXT_commonExec.sch
+++ b/src/main/resources/EXT_commonExec.sch
@@ -367,7 +367,7 @@
         <!-- For each InputSet which is a child of a callActivity applies: -->
         <!-- The structureRef of the (indirectly) referenced ItemDefinition must be the same as the structureRef of the
         (indirectly) referenced itemDefinition of the called Process/GlobalTask -->
-        <iso:rule context="bpmn:inputSet[ancestor::bpmn:callActivity and node()]">
+        <iso:rule context="bpmn:inputSet[ancestor::bpmn:callActivity/bpmn:ioSpecification/bpmn:dataInput[@itemSubjectRef] and node()]">
             <iso:assert test="//bpmn:itemDefinition[@id=//bpmn:dataInput[@id=current()/bpmn:dataInputRefs]/@itemSubjectRef]/@structureRef =
         //bpmn:itemDefinition[@id=//bpmn:dataInput[@id=//bpmn:*[@id=//bpmn:callActivity[bpmn:ioSpecification/bpmn:inputSet=current()]
                 /@calledElement]/bpmn:ioSpecification/bpmn:inputSet/bpmn:dataInputRefs]/@itemSubjectRef]/@structureRef" diagnostics="id">
@@ -380,7 +380,7 @@
         <!-- For each OutputSet which is a child of a callActivity applies: -->
         <!-- The structureRef of the (indirectly) referenced ItemDefinition must be the same as the structureRef of the
         (indirectly) referenced itemDefinition of the called Process/GlobalTask -->
-        <iso:rule context="bpmn:outputSet[ancestor::bpmn:callActivity and node()]">
+        <iso:rule context="bpmn:outputSet[ancestor::bpmn:callActivity/bpmn:ioSpecification/bpmn:dataOutput[@itemSubjectRef] and node()]">
             <iso:assert test="//bpmn:itemDefinition[@id=//bpmn:dataOutput[@id=current()/bpmn:dataOutputRefs]/@itemSubjectRef]/@structureRef =
         //bpmn:itemDefinition[@id=//bpmn:dataOutput[@id=//bpmn:*[@id=//bpmn:callActivity[bpmn:ioSpecification/bpmn:outputSet=current()]
                 /@calledElement]/bpmn:ioSpecification/bpmn:outputSet/bpmn:dataOutputRefs]/@itemSubjectRef]/@structureRef" diagnostics="id">
@@ -393,7 +393,7 @@
         <!-- For each dataInput which is a child of a callActivity applies: -->
         <!-- The structureRef of the (indirectly) referenced ItemDefinition must be the same as the structureRef of the
         (indirectly) referenced itemDefinition of the called Process/GlobalTask -->
-        <iso:rule context="bpmn:dataInput[ancestor::bpmn:callActivity]">
+        <iso:rule context="bpmn:dataInput[ancestor::bpmn:callActivity and @itemSubjectRef]">
             <iso:assert test="//bpmn:itemDefinition[@id=current()/@itemSubjectRef]/@structureRef =
         //bpmn:itemDefinition[@id=
                 //bpmn:*[@id=//bpmn:callActivity[bpmn:ioSpecification/bpmn:dataInput=current()]/@calledElement]
@@ -407,7 +407,7 @@
         <!-- For each dataOutput which is a child of a callActivity applies: -->
         <!-- The structureRef of the (indirectly) referenced ItemDefinition must be the same as the structureRef of the
         (indirectly) referenced itemDefinition of the called Process/GlobalTask -->
-        <iso:rule context="bpmn:dataOutput[ancestor::bpmn:callActivity]">
+        <iso:rule context="bpmn:dataOutput[ancestor::bpmn:callActivity and @itemSubjectRef]">
             <iso:assert test="//bpmn:itemDefinition[@id=current()/@itemSubjectRef]/@structureRef =
         //bpmn:itemDefinition[@id=
                 //bpmn:*[@id=//bpmn:callActivity[bpmn:ioSpecification/bpmn:dataOutput=current()]/@calledElement]

--- a/src/test/java/de/uniba/dsg/bpmnspector/schematron/commonExec/Ext063.java
+++ b/src/test/java/de/uniba/dsg/bpmnspector/schematron/commonExec/Ext063.java
@@ -48,10 +48,10 @@ public class Ext063 extends TestCase {
         ValidationResult result = verifyInvalidResult(createFile("EXT063_failure_calledProcess_itemsNotMatching.bpmn"), 2);
         assertViolation(result.getViolations().get(0),
                 ERR_MSG,
-                "(//bpmn:outputSet[ancestor::bpmn:callActivity and node()])[1]", 73);
+                "(//bpmn:outputSet[ancestor::bpmn:callActivity/bpmn:ioSpecification/bpmn:dataOutput[@itemSubjectRef] and node()])[1]", 73);
         assertViolation(result.getViolations().get(1),
                 ERR_MSG,
-                "(//bpmn:dataOutput[ancestor::bpmn:callActivity])[1]", 69);
+                "(//bpmn:dataOutput[ancestor::bpmn:callActivity and @itemSubjectRef])[1]", 69);
     }
 
     @Test


### PR DESCRIPTION
Changes:
* Validates the referenced `itemSubjectRef` only if the attribute `itemSubjectRef` is used
* Fixes build in order to test the changes
  * Copied the **maven-alfresco** address from https://github.com/uniba-dsg/BPMNspector/pull/13